### PR TITLE
Converting code to use C++(11) idioms instead of C

### DIFF
--- a/tools/sailfish_tools_system_action.cpp
+++ b/tools/sailfish_tools_system_action.cpp
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     }
 
     const std::string cmd(argv[1]);
-    for (auto &action: actions) {
+    for (const auto &action: actions) {
         if (cmd == action.name) {
             auto rc = action.fn(argc, argv);
             if (rc)


### PR DESCRIPTION
As we already use C++11 lambdas, we should also use foreach and std::string.
