### PR TITLE
[rpmdb] request pk-rpm-db-clean to rebuild db if it exists

### DIFF
--- a/tools/repair_rpm_db.sh
+++ b/tools/repair_rpm_db.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
-pkill store
-rm -f /var/lib/rpm/__db.00*
-rpm --rebuilddb
+if ls /usr/libexec/pk-rpm-db-clean; then
+    echo "Leave request to rebuild rpm db on restart"
+    mkdir -p /var/lib/PackageKit
+    touch /var/lib/PackageKit/scheduled-rebuilddb
+else
+    echo "Manually rebuild db and reboot"
+    pkill store
+    pkill packagekitd
+    sleep 4
+    pkill -9 store
+    pkill -9 packagekitd
+    rm -f /var/lib/rpm/__db.00*
+    rpm --rebuilddb
+fi
 


### PR DESCRIPTION
/usr/libexec/pk-rpm-db-clean rebuilds rpm db on boot automatically if
/var/lib/PackageKit/scheduled-rebuilddb exists, so ask it to do the
job if it is possible

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
