### PR TITLE
[ui] Added possibility to restart keyboard

### DIFF
--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -76,6 +76,20 @@ Column {
         }
 
         ActionItem {
+            //% "Restart keyboard"
+            actionName: qsTrId("sailfish-tools-restart-keyboard")
+            deviceLockRequired: false
+            //% "Restart keyboard if it gets stuck or clipboard stops working."
+            description: qsTrId("sailfish-utilities-restart-keyboard-desc")
+
+            function action(on_reply, on_error) {
+                tools.request("restartKeyboard", {}, {
+                    on_reply: on_reply, on_error: on_error
+                });
+            }
+        }
+
+        ActionItem {
             //% "Clean backup storage"
             actionName: qsTrId("sailfish-tools-clean-backup")
             //% "Clean backup storage to free space occupied by backups."

--- a/qml/tools.js
+++ b/qml/tools.js
@@ -27,6 +27,11 @@ exports.cleanTrackerDb = function(msg, ctx) {
     os.system("tracker-control", ["-krs"]);
 };
 
+exports.restartKeyboard = function(msg, ctx) {
+    var os = require("os");
+    os.system("systemctl", ["--user", "restart", "maliit-server.service"]);
+};
+
 exports.restartAlien = make_system_action("restart_dalvik");
 exports.stopAlien = make_system_action("stop_dalvik");
 exports.restartNetwork = make_system_action("restart_network");


### PR DESCRIPTION
Sometimes the keyboard can get stuck or clipboard stops working so this should be handy. First time doing this so maybe I've made some mistakes.

I'm not sure if it should be higher up in the list of utilities in case the stuck keyboard would overlap with the button that needs to be pressed to restart it, this probably needs some testing.