### PR TITLE
[alien] Remove Alien control items (Fixes JB#29612)

### DIFF
--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -25,39 +25,6 @@ Column {
         width: parent.width
         spacing: Theme.paddingLarge
         ActionItem {
-            //% "Restart Alien Dalvik"
-            actionName: qsTrId("sailfish-tools-restart-dalvik")
-            deviceLockRequired: false
-            //% "Restart subsystem providing support to run "
-            //% "Android applications. Try to use it if Android applications can't be "
-            //% " started or stuck etc."
-            description: qsTrId("sailfish-utilities-me-restart-alien-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("restartAlien", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Stop Android™ runtime"
-            actionName: qsTrId("sailfish-tools-bt-stop-android")
-            deviceLockRequired: false
-            //% "Stop Android™ runtime to conserve memory and/or power."
-            //% " All Android™ applications (including background"
-            //% " services, e.g. instant messaging applications) will be stopped."
-            //% " See also <a href='https://together.jolla.com/question/20472/why-not-shutdown-aliendalvik-after-closing-last-android-app/'>here</a>."
-            description: qsTrId("sailfish-utilities-stop-alien-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("stopAlien", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
             //% "Restart network"
             actionName: qsTrId("sailfish-tools-me-restart-network")
             deviceLockRequired: false

--- a/qml/tools.js
+++ b/qml/tools.js
@@ -32,6 +32,4 @@ exports.restartKeyboard = function(msg, ctx) {
     os.system("systemctl", ["--user", "restart", "maliit-server.service"]);
 };
 
-exports.restartAlien = make_system_action("restart_dalvik");
-exports.stopAlien = make_system_action("stop_dalvik");
 exports.restartNetwork = make_system_action("restart_network");

--- a/tools/sailfish_tools_system_action.cpp
+++ b/tools/sailfish_tools_system_action.cpp
@@ -64,12 +64,6 @@ std::map<std::string, action_type> actions = {
     { "repair_rpm_db", [](action_ctx const *) {
             execute_own_utility("repair_rpm_db.sh");
         }},
-    { "restart_dalvik", [](action_ctx const *) {
-            service_do("aliendalvik", "restart");
-        }},
-    { "stop_dalvik", [](action_ctx const *) {
-            service_do("aliendalvik", "stop");
-        }},
     { "restart_network", [](action_ctx const *) {
             return execute_own_utility("restart_network.sh");
         }}


### PR DESCRIPTION
Merge this in the future at a point when the Alien settings plugin is available (because current releases still have a use for these features). Or maybe we should just hide those when we detect that the Alien settings page is available?