### PR TITLE
Load Android control plugins only if needed

### DIFF
--- a/harbour.changes
+++ b/harbour.changes
@@ -1,0 +1,4 @@
+* Thu Jun 25 13:36:41 EEST 2015 - 0.0.11
+
+- Android controls are loaded only if Android support is installed and
+  separate Settings page is not installed

--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -21,122 +21,29 @@ Column {
         title: qsTrId("sailfish-tools-utilities")
     }
 
+    ListModel {
+        id: plugins
+    }
+    Component.onCompleted: {
+        var justLoad = function(name) {
+            var info = { name: name, path: "plugins/" + name + ".qml" }
+            plugins.append(info)
+        }
+        var names = [ "RestartKeyboard", "RestartNetwork"
+                      , "CleanBackup", "CleanPackageCache", "CleanTracker"
+                      , "RestartAndroid", "StopAndroid" ]
+        for (var i = 0; i < names.length; ++i)
+            justLoad(names[i])
+
+    }
     Column {
         width: parent.width
         spacing: Theme.paddingLarge
-        ActionItem {
-            //% "Restart Alien Dalvik"
-            actionName: qsTrId("sailfish-tools-restart-dalvik")
-            deviceLockRequired: false
-            //% "Restart subsystem providing support to run "
-            //% "Android applications. Try to use it if Android applications can't be "
-            //% " started or stuck etc."
-            description: qsTrId("sailfish-utilities-me-restart-alien-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("restartAlien", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Stop Android™ runtime"
-            actionName: qsTrId("sailfish-tools-bt-stop-android")
-            deviceLockRequired: false
-            //% "Stop Android™ runtime to conserve memory and/or power."
-            //% " All Android™ applications (including background"
-            //% " services, e.g. instant messaging applications) will be stopped."
-            //% " See also <a href='https://together.jolla.com/question/20472/why-not-shutdown-aliendalvik-after-closing-last-android-app/'>here</a>."
-            description: qsTrId("sailfish-utilities-stop-alien-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("stopAlien", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Restart network"
-            actionName: qsTrId("sailfish-tools-me-restart-network")
-            deviceLockRequired: false
-            //% "Restart network subsystem if anything wrong happened with "
-            //% "connectivity (WLAN, mobile data)."
-            //% "Ignore the warning asking you to restart device because "
-            //% "SIM is removed. This is the side effect of the network "
-            //% "stack beeing restarted"
-            description: qsTrId("sailfish-utilities-me-restart-network-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("restartNetwork", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Restart keyboard"
-            actionName: qsTrId("sailfish-tools-restart-keyboard")
-            deviceLockRequired: false
-            //% "Restart keyboard if it gets stuck or clipboard stops working."
-            description: qsTrId("sailfish-utilities-restart-keyboard-desc")
-
-            function action(on_reply, on_error) {
-                tools.request("restartKeyboard", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Clean backup storage"
-            actionName: qsTrId("sailfish-tools-clean-backup")
-            //% "Clean backup storage to free space occupied by backups."
-            //% " All backups will be removed"
-            description: qsTrId("sailfish-utilities-me-clean-backups-desc")
-            //% "Removing backups"
-            remorseText: qsTrId("sailfish-utilities-me-remorse-removing-backups")
-
-            function action(on_reply, on_error) {
-                tools.request("removeBackups", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Clean package cache"
-            actionName: qsTrId("sailfish-tools-clean-pkg-cache")
-            //% "Package cache cleaning can be tried if there are "
-            //% "problems with store, e.g. 'Critical problem with the app registry' error. "
-            //% "More information can be found "
-            //% "<a href='https://together.jolla.com/question/7988/problem-with-store-unable-to-install/'>here</a>."
-            description: qsTrId("sailfish-utilities-me-clean-pkg-cache-desc")
-            requiresReboot: true
-
-            function action(on_reply, on_error) {
-                tools.request("cleanRpmDb", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
-            }
-        }
-
-        ActionItem {
-            //% "Clean tracker dabatase"
-            actionName: qsTrId("sailfish-tools-clean-tracker-db")
-            //% "Tracker dabatabase cleaning can help in cases with "
-            //% "missing images, audio files etc. Processes using tracker "
-            //% "will be closed, tracker reindexing will be started. "
-            //% "More information can be found "
-            //% "<a href='https://together.jolla.com/question/4337/refresh-tracker/'>here</a>."
-            description: qsTrId("sailfish-utilities-me-clean-tracker-db-desc")
-            deviceLockRequired: false
-
-            function action(on_reply, on_error) {
-                tools.request("cleanTrackerDb", {}, {
-                    on_reply: on_reply, on_error: on_error
-                });
+        Repeater {
+            model: plugins
+            Loader {
+                source: path
+                width: parent.width
             }
         }
     }

--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -30,11 +30,19 @@ Column {
             plugins.append(info)
         }
         var names = [ "RestartKeyboard", "RestartNetwork"
-                      , "CleanBackup", "CleanPackageCache", "CleanTracker"
-                      , "RestartAndroid", "StopAndroid" ]
+                      , "CleanBackup", "CleanPackageCache", "CleanTracker" ]
         for (var i = 0; i < names.length; ++i)
             justLoad(names[i])
 
+        tools.request("isAndroidControlNeeded", {}, {
+            on_reply: function(is_show) {
+                if (is_show) {
+                    justLoad("StopAndroid")
+                    justLoad("RestartAndroid")
+                }
+            }, on_error: function(e) {
+                console.log("Error", e)
+            }});
     }
     Column {
         width: parent.width

--- a/qml/CMakeLists.txt
+++ b/qml/CMakeLists.txt
@@ -1,10 +1,19 @@
-FILE(GLOB JS_FILES *.js)
-FILE(GLOB QML_FILES *.qml)
+set(COMPONENT_DIR lib/qt5/qml/Sailfish/Utilities)
+set(JS_FILES
+  tools.js
+  )
+
+set(QML_FILES
+  ActionList.qml
+  MainPage.qml
+  )
 
 install(
-  FILES ${JS_FILES} ${QML_FILES} ${SVG_FILES}
+  FILES ${JS_FILES} ${QML_FILES}
   DESTINATION share/${PACKAGE_NAME}
   )
+
+install(FILES qmldir ActionItem.qml DESTINATION ${COMPONENT_DIR})
 
 add_custom_command(
     OUTPUT settings-sailfish_utilities.ts
@@ -21,3 +30,5 @@ add_dependencies(qm_target ts_target)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/settings-sailfish_utilities.ts DESTINATION share/translations/source)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/settings-sailfish_utilities_eng_en.qm DESTINATION share/translations)
+
+add_subdirectory(plugins)

--- a/qml/DemoItems.qml
+++ b/qml/DemoItems.qml
@@ -8,6 +8,7 @@
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
 
 Column {
 

--- a/qml/plugins/CMakeLists.txt
+++ b/qml/plugins/CMakeLists.txt
@@ -1,0 +1,6 @@
+FILE(GLOB QML_FILES *.qml)
+
+install(
+  FILES ${QML_FILES}
+  DESTINATION share/${PACKAGE_NAME}/plugins
+  )

--- a/qml/plugins/CleanBackup.qml
+++ b/qml/plugins/CleanBackup.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Clean backup storage"
+    actionName: qsTrId("sailfish-tools-clean-backup")
+    //% "Clean backup storage to free space occupied by backups."
+    //% " All backups will be removed"
+    description: qsTrId("sailfish-utilities-me-clean-backups-desc")
+    //% "Removing backups"
+    remorseText: qsTrId("sailfish-utilities-me-remorse-removing-backups")
+
+    function action(on_reply, on_error) {
+        tools.request("removeBackups", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/CleanPackageCache.qml
+++ b/qml/plugins/CleanPackageCache.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Clean package cache"
+    actionName: qsTrId("sailfish-tools-clean-pkg-cache")
+    //% "Package cache cleaning can be tried if there are "
+    //% "problems with store, e.g. 'Critical problem with the app registry' error. "
+    //% "More information can be found "
+    //% "<a href='https://together.jolla.com/question/7988/problem-with-store-unable-to-install/'>here</a>."
+    description: qsTrId("sailfish-utilities-me-clean-pkg-cache-desc")
+    requiresReboot: true
+
+    function action(on_reply, on_error) {
+        tools.request("cleanRpmDb", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/CleanTracker.qml
+++ b/qml/plugins/CleanTracker.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Clean tracker dabatase"
+    actionName: qsTrId("sailfish-tools-clean-tracker-db")
+    //% "Tracker dabatabase cleaning can help in cases with "
+    //% "missing images, audio files etc. Processes using tracker "
+    //% "will be closed, tracker reindexing will be started. "
+    //% "More information can be found "
+    //% "<a href='https://together.jolla.com/question/4337/refresh-tracker/'>here</a>."
+    description: qsTrId("sailfish-utilities-me-clean-tracker-db-desc")
+    deviceLockRequired: false
+
+    function action(on_reply, on_error) {
+        tools.request("cleanTrackerDb", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/RestartAndroid.qml
+++ b/qml/plugins/RestartAndroid.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Restart Alien Dalvik"
+    actionName: qsTrId("sailfish-tools-restart-dalvik")
+    deviceLockRequired: false
+    //% "Restart subsystem providing support to run "
+    //% "Android applications. Try to use it if Android applications can't be "
+    //% " started or stuck etc."
+    description: qsTrId("sailfish-utilities-me-restart-alien-desc")
+
+    function action(on_reply, on_error) {
+        tools.request("restartAlien", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/RestartKeyboard.qml
+++ b/qml/plugins/RestartKeyboard.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Restart keyboard"
+    actionName: qsTrId("sailfish-tools-restart-keyboard")
+    deviceLockRequired: false
+    //% "Restart keyboard if it gets stuck or clipboard stops working."
+    description: qsTrId("sailfish-utilities-restart-keyboard-desc")
+
+    function action(on_reply, on_error) {
+        tools.request("restartKeyboard", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/RestartNetwork.qml
+++ b/qml/plugins/RestartNetwork.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Restart network"
+    actionName: qsTrId("sailfish-tools-me-restart-network")
+    deviceLockRequired: false
+    //% "Restart network subsystem if anything wrong happened with "
+    //% "connectivity (WLAN, mobile data)."
+    //% "Ignore the warning asking you to restart device because "
+    //% "SIM is removed. This is the side effect of the network "
+    //% "stack beeing restarted"
+    description: qsTrId("sailfish-utilities-me-restart-network-desc")
+
+    function action(on_reply, on_error) {
+        tools.request("restartNetwork", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/plugins/StopAndroid.qml
+++ b/qml/plugins/StopAndroid.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Silica.theme 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Stop Android™ runtime"
+    actionName: qsTrId("sailfish-tools-bt-stop-android")
+    deviceLockRequired: false
+    //% "Stop Android™ runtime to conserve memory and/or power."
+    //% " All Android™ applications (including background"
+    //% " services, e.g. instant messaging applications) will be stopped."
+    //% " See also <a href='https://together.jolla.com/question/20472/why-not-shutdown-aliendalvik-after-closing-last-android-app/'>here</a>."
+    description: qsTrId("sailfish-utilities-stop-alien-desc")
+
+    function action(on_reply, on_error) {
+        tools.request("stopAlien", {}, {
+            on_reply: on_reply, on_error: on_error
+        });
+    }
+}

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -1,0 +1,2 @@
+module Sailfish.Utilities
+ActionItem 1.0 ActionItem.qml

--- a/qml/tools.js
+++ b/qml/tools.js
@@ -32,6 +32,13 @@ exports.restartKeyboard = function(msg, ctx) {
     os.system("systemctl", ["--user", "restart", "maliit-server.service"]);
 };
 
+exports.isAndroidControlNeeded = function(msg, ctx) {
+    var os = require("os");
+    var rc = os.system("rpm", ["-q", "aliendalvik"]);
+    return (rc === 0
+            && os.system("rpm", ["-q", "apkd-android-settings"]) !== 0);
+};
+
 exports.restartAlien = make_system_action("restart_dalvik");
 exports.stopAlien = make_system_action("stop_dalvik");
 exports.restartNetwork = make_system_action("restart_network");

--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -54,13 +54,18 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %attr(4754, root, privileged) %{_bindir}/sailfish_tools_system_action
+%dir %{_datadir}/sailfish-utilities
 %{_datadir}/sailfish-utilities/*.qml
 %{_datadir}/sailfish-utilities/*.js
 %{_datadir}/sailfish-utilities/*.sh
+%dir %{_datadir}/sailfish-utilities/plugins
+%{_datadir}/sailfish-utilities/plugins/*.qml
 %{_datadir}/jolla-settings/entries/utilities.json
 %{_datadir}/translations/settings-sailfish_utilities_eng_en.qm
 %{_datadir}/lipstick/notificationcategories/x-sailfish.sailfish-utilities.error.conf
 %{_datadir}/lipstick/notificationcategories/x-sailfish.sailfish-utilities.info.conf
+%dir %{_libdir}/qt5/qml/Sailfish/Utilities
+%{_libdir}/qt5/qml/Sailfish/Utilities/*
 
 %files ts-devel
 %defattr(-,root,root,-)


### PR DESCRIPTION
2 commits:

1) taking out ActionItems as utilities plugins (using ActionItem component)

2) load Android controls only if Alien is installed and there is no corresponding control page in Settings