### PR TITLE
[plugin] restart tracker when cleaning database. Contributes to MER#1319

### DIFF
--- a/qml/tools.js
+++ b/qml/tools.js
@@ -24,7 +24,7 @@ exports.cleanRpmDb = make_system_action("repair_rpm_db");
 
 exports.cleanTrackerDb = function(msg, ctx) {
     var os = require("os");
-    os.system("tracker-control", ["-krs"]);
+    os.system("systemctl", ["--user", "start", "tracker-reindex.service"]);
 };
 
 exports.restartKeyboard = function(msg, ctx) {

--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -37,6 +37,8 @@ Summary: Translation source for %{name}
 %description ts-devel
 Translation source for %{name}
 
+%define _userunitdir %{_libdir}/systemd/user/
+
 %prep
 %setup -q
 
@@ -66,6 +68,7 @@ rm -rf %{buildroot}
 %{_datadir}/lipstick/notificationcategories/x-sailfish.sailfish-utilities.info.conf
 %dir %{_libdir}/qt5/qml/Sailfish/Utilities
 %{_libdir}/qt5/qml/Sailfish/Utilities/*
+%{_userunitdir}/tracker-reindex.service
 
 %files ts-devel
 %defattr(-,root,root,-)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,6 +4,12 @@ set(CMAKE_CXX_FLAGS
 configure_file(config.hpp.in config.hpp @ONLY)
 add_executable(sailfish_tools_system_action sailfish_tools_system_action.cpp)
 
+configure_file(tracker-reindex.service.in tracker-reindex.service @ONLY)
+
+install(FILES
+  tracker-reindex.service
+  DESTINATION lib/systemd/user
+  )
 
 install(TARGETS
       sailfish_tools_system_action
@@ -15,5 +21,6 @@ install(PROGRAMS
       repair_rpm_db.sh
       restart_network.sh
       restart_lipstick.sh
+      tracker_reindex.sh
       DESTINATION share/sailfish-utilities
 )

--- a/tools/tracker-reindex.service.in
+++ b/tools/tracker-reindex.service.in
@@ -1,0 +1,5 @@
+[Unit]
+Description=Tracker database cleanup and reindexing
+
+[Service]
+ExecStart=@DEPLOYMENT_PATH@/tracker_reindex.sh

--- a/tools/tracker_reindex.sh
+++ b/tools/tracker_reindex.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+systemctl --user stop tracker-extract.service
+systemctl --user stop tracker-miner-fs.service
+systemctl --user stop tracker-store.service
+
+tracker-control -krs
+
+systemctl --user start tracker-store.service
+systemctl --user start tracker-miner-fs.service
+systemctl --user start tracker-extract.service


### PR DESCRIPTION
tracker-control deduces uids of processes in the wrong way - in some cases it
works incorrectly, so it does not kill all tracker processes owned by the same
user and reindexing does not happen. So, workaround is to restart tracker
services and do it from the separate systemd user session service, maybe even
buggy tracker could find buddies in this case ;-)

Signed-off-by: Denis Zalevskiy <denis.zalevskiy@jolla.com>