### PR TITLE
[l10n] Remove advice on SIM card removal warning. Contributes to MER#1305

### DIFF
--- a/qml/plugins/RestartNetwork.qml
+++ b/qml/plugins/RestartNetwork.qml
@@ -9,9 +9,6 @@ ActionItem {
     deviceLockRequired: false
     //% "Restart network subsystem if anything wrong happened with "
     //% "connectivity (WLAN, mobile data)."
-    //% "Ignore the warning asking you to restart device because "
-    //% "SIM is removed. This is the side effect of the network "
-    //% "stack beeing restarted"
     description: qsTrId("sailfish-utilities-me-restart-network-desc")
 
     function action(on_reply, on_error) {


### PR DESCRIPTION
On Sailfish OS 2.0, no prompt for device restart due to SIM card removal appears anymore when restarting network connections. This warning should no longer be necessary.

As requested on TJC, https://together.jolla.com/question/112466/sailifish-utilities-ignore-restart-now-later-text-can-be-removed-now/