### PR TITLE
[utilities] Update tracker reset script to new Tracker version. Fixes JB#26676

### DIFF
--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -18,6 +18,7 @@ Requires: nemo-qml-plugin-notifications-qt5
 Requires: nemo-qml-plugin-systemsettings
 Requires: nemo-qml-plugin-dbus-qt5
 Requires:  mapplauncherd-booster-silica-qt5
+Requires: tracker >= 1.3.2
 BuildRequires: cmake >= 2.8
 BuildRequires: qt5-default
 BuildRequires: qt5-qttools

--- a/tools/tracker_reindex.sh
+++ b/tools/tracker_reindex.sh
@@ -1,11 +1,3 @@
 #!/bin/sh
 
-systemctl --user stop tracker-extract.service
-systemctl --user stop tracker-miner-fs.service
-systemctl --user stop tracker-store.service
-
-tracker-control -krs
-
-systemctl --user start tracker-store.service
-systemctl --user start tracker-miner-fs.service
-systemctl --user start tracker-extract.service
+tracker reset --hard


### PR DESCRIPTION
Update the script tracker_reindex.sh to the new command syntax was introduced in Tracker 1.3.2. Also remove the stop and start calls around it, as the reset already does this and could lead to rapid restarts causing database problems.
Make this version dependent on a compatible tracker version being installed, so it doesn't end up on earlier Sailfish versions. 