### PR TITLE
[sailfish-utilities] Fix translation pack dependency. Fixes JB#36410

### DIFF
--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -26,10 +26,9 @@ BuildRequires: pkgconfig(Qt5Qml)
 BuildRequires: pkgconfig(Qt5Quick)
 BuildRequires: pkgconfig(Qt5Gui)
 %if %{with l10n}
-BuildRequires: %{name}-all-translations
-#!BuildIgnore: %{name}-all-translations-pack
-%define _all_translations_version %(rpm -q --queryformat "%%{version}-%%{release}" %{name}-all-translations)
-Requires: %{name}-all-translations >= %{_all_translations_version}
+BuildRequires: %{name}-all-translations-pack
+%define _all_translations_version %(rpm -q --queryformat "%%{version}-%%{release}" %{name}-all-translations-pack)
+Requires: %{name}-all-translations-pack >= %{_all_translations_version}
 %endif
 
 %description


### PR DESCRIPTION
Correctly require the real translations-pack package instead of the virtual provides one