### PR TITLE
Avoid unnecessary notification category files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,6 @@ set(DEPLOYMENT_PATH ${prefix}/share/${PACKAGE_NAME})
 
 configure_file(utilities.json.in utilities.json @ONLY)
 install(FILES utilities.json DESTINATION share/jolla-settings/entries)
-install(
-  FILES x-sailfish.sailfish-utilities.error.conf x-sailfish.sailfish-utilities.info.conf
-  DESTINATION share/lipstick/notificationcategories
-)
 
 add_subdirectory(qml)
 add_subdirectory(plugin)

--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -57,9 +57,6 @@ Page {
 
     function actionIsDone(category, message) {
         console.log("Notify", message);
-        notification.category = (category === "error")
-            ? "x-sailfish.sailfish-utilities.error"
-            : "x-sailfish.sailfish-utilities.info";
         //% "Sailfish Utilities"
         notification.previewBody = qsTrId("sailfish-utilities-me-name");
         notification.previewSummary = message;
@@ -92,7 +89,7 @@ Page {
     }
     Notification {
         id: notification
-        category: "x-sailfish.sailfish-utilities.error"
+        icon: "icon-m-health"
     }
 
     BusyIndicator {

--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -65,8 +65,6 @@ rm -rf %{buildroot}
 %{_datadir}/sailfish-utilities/plugins/*.qml
 %{_datadir}/jolla-settings/entries/utilities.json
 %{_datadir}/translations/settings-sailfish_utilities_eng_en.qm
-%{_datadir}/lipstick/notificationcategories/x-sailfish.sailfish-utilities.error.conf
-%{_datadir}/lipstick/notificationcategories/x-sailfish.sailfish-utilities.info.conf
 %dir %{_libdir}/qt5/qml/Sailfish/Utilities
 %{_libdir}/qt5/qml/Sailfish/Utilities/*
 %{_userunitdir}/tracker-reindex.service

--- a/x-sailfish.sailfish-utilities.error.conf
+++ b/x-sailfish.sailfish-utilities.error.conf
@@ -1,3 +1,0 @@
-x-nemo-icon=icon-m-health
-x-nemo-preview-icon=icon-m-health
-x-nemo-priority=100

--- a/x-sailfish.sailfish-utilities.info.conf
+++ b/x-sailfish.sailfish-utilities.info.conf
@@ -1,3 +1,0 @@
-x-nemo-icon=icon-m-health
-x-nemo-preview-icon=icon-m-health
-x-nemo-priority=100


### PR DESCRIPTION
preview icon falls back to common icon -> no need for both
priority is not used on transient notification -> can just skip

@rainemak @jpetrell 