### PR TITLE
[sailfish-utilities] Remove dependency to qt5-qtdeclarative-systeminfo. Contributes to JB#47580

### DIFF
--- a/rpm/sailfish-utilities.spec
+++ b/rpm/sailfish-utilities.spec
@@ -10,7 +10,6 @@ URL: https://github.com/sailfishos/sailfish-utilities
 Source0: %{name}-%{version}.tar.bz2
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires:  sailfishsilica-qt5
-Requires: qt5-qtdeclarative-systeminfo
 Requires: jolla-settings-system >= 0.1.69
 Requires: nemo-qml-plugin-notifications-qt5
 Requires: nemo-qml-plugin-devicelock


### PR DESCRIPTION
This isn't even imported anywhere.

@spiiroin
