### PR TITLE
[sailfish-utilities] Add a Restart Bluetooth button. JB#58019

### DIFF
--- a/plugin/utiltools.cpp
+++ b/plugin/utiltools.cpp
@@ -30,6 +30,11 @@ void UtilTools::restartNetwork(QJSValue successCallback, QJSValue errorCallback)
     execute(SystemTool, QStringList("restart_network"), successCallback, errorCallback);
 }
 
+void UtilTools::restartBluetooth(QJSValue successCallback, QJSValue errorCallback)
+{
+    execute(SystemTool, QStringList("restart_bluetooth"), successCallback, errorCallback);
+}
+
 void UtilTools::restartLipstick(QJSValue successCallback, QJSValue errorCallback)
 {
     execute(SystemTool, QStringList("restart_lipstick"), successCallback, errorCallback);

--- a/plugin/utiltools.h
+++ b/plugin/utiltools.h
@@ -21,6 +21,9 @@ public:
     Q_INVOKABLE void restartNetwork(QJSValue successCallback = QJSValue::UndefinedValue,
                                     QJSValue errorCallback = QJSValue::UndefinedValue);
 
+    Q_INVOKABLE void restartBluetooth(QJSValue successCallback = QJSValue::UndefinedValue,
+                                      QJSValue errorCallback = QJSValue::UndefinedValue);
+
     Q_INVOKABLE void restartLipstick(QJSValue successCallback = QJSValue::UndefinedValue,
                                      QJSValue errorCallback = QJSValue::UndefinedValue);
 

--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -29,8 +29,9 @@ Column {
             plugins.append(info)
         }
         var names = [ "RestartNetwork", "RestartUI",
-                      "CleanPackageCache", "CleanTracker",
-                      "RestartFingerprint"]
+                      "RestartFingerprint", "RestartBluetooth",
+                      "CleanPackageCache", "CleanTracker"
+                    ]
         for (var i = 0; i < names.length; ++i)
             justLoad(names[i])
     }

--- a/qml/plugins/RestartBluetooth.qml
+++ b/qml/plugins/RestartBluetooth.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Bluetooth"
+    title: qsTrId("sailfish-tools-he-bluetooth")
+    //% "Restart"
+    actionName: qsTrId("sailfish-tools-bt-restart")
+    deviceLockRequired: false
+    //% "Restart Bluetooth subsystem, which may help if you're "
+    //% "having trouble scanning or connecting to a Bluetooth "
+    //% "device which worked previously."
+    description: qsTrId("sailfish-utilities-me-restart_bluetooth_desc")
+
+    function action(on_reply, on_error) {
+        UtilTools.restartBluetooth(on_reply, on_error)
+    }
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,6 +20,7 @@ install(TARGETS
 install(PROGRAMS
       repair_rpm_db.sh
       restart_network.sh
+      restart_bluetooth.sh
       restart_lipstick.sh
       tracker_reindex.sh
       restart_fingerprint.sh

--- a/tools/restart_bluetooth.sh
+++ b/tools/restart_bluetooth.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+warning() {
+    printf "%s: Warning: %s\n" "$(basename $0)" "$*" 1>&2
+}
+
+service_do() {
+    if systemctl "$1" "$2"; then
+        return 0;
+    else
+        warning "Status $? on" "${@}"
+        return 1;
+    fi
+}
+
+service_do restart bluetooth
+systemctl is-active --quiet bluetooth-rfkill-event && service_do restart bluetooth-rfkill-event
+systemctl is-active --quiet bluebinder             && service_do restart bluebinder

--- a/tools/sailfish_tools_system_action.cpp
+++ b/tools/sailfish_tools_system_action.cpp
@@ -61,6 +61,9 @@ std::map<std::string, action_type> actions = {
     { "restart_lipstick", [](action_ctx const *) {
             return execute_own_utility("restart_lipstick.sh");
         }},
+    { "restart_bluetooth", [](action_ctx const *) {
+            return execute_own_utility("restart_bluetooth.sh");
+        }},
     { "restart_network", [](action_ctx const *) {
             return execute_own_utility("restart_network.sh");
         }},
@@ -73,7 +76,7 @@ std::map<std::string, action_type> actions = {
 };
 
 std::set<std::string> root_actions = {
-    "repair_rpm_db", "restart_network", "restart_fingerprint"
+    "repair_rpm_db", "restart_network", "restart_fingerprint", "restart_bluetooth"
 };
 
 class BecomeRoot


### PR DESCRIPTION
This adds a new option in the Utilities Menu to restart the Bluetooth related services, dealing with [this feature request](https://forum.sailfishos.org/t/add-bluetooth-reset-restart-to-the-sailfish-utilities-app/5407)

Please review and comment:

- Are the calls to systemctl in restart_bluetooth.sh correct?
- There are two translation strings, one for the name "Bluetooth" and the description of the option itself.  


Resolves: #61 