### PR TITLE
 [sailfish-utilities] Add a Restart Fingerprint button. Fixes JB#57941

### DIFF
--- a/plugin/utiltools.cpp
+++ b/plugin/utiltools.cpp
@@ -35,6 +35,11 @@ void UtilTools::restartLipstick(QJSValue successCallback, QJSValue errorCallback
     execute(SystemTool, QStringList("restart_lipstick"), successCallback, errorCallback);
 }
 
+void UtilTools::restartFingerprint(QJSValue successCallback, QJSValue errorCallback)
+{
+    execute(SystemTool, QStringList("restart_fingerprint"), successCallback, errorCallback);
+}
+
 void UtilTools::handleProcessExit(int exitCode, QProcess::ExitStatus status)
 {
     QProcess *process = qobject_cast<QProcess*>(sender());

--- a/plugin/utiltools.h
+++ b/plugin/utiltools.h
@@ -24,6 +24,9 @@ public:
     Q_INVOKABLE void restartLipstick(QJSValue successCallback = QJSValue::UndefinedValue,
                                      QJSValue errorCallback = QJSValue::UndefinedValue);
 
+    Q_INVOKABLE void restartFingerprint(QJSValue successCallback = QJSValue::UndefinedValue,
+                                        QJSValue errorCallback = QJSValue::UndefinedValue);
+
 private slots:
     void handleProcessExit(int exitCode, QProcess::ExitStatus status);
 

--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -29,7 +29,8 @@ Column {
             plugins.append(info)
         }
         var names = [ "RestartNetwork", "RestartUI",
-                      "CleanPackageCache", "CleanTracker" ]
+                      "CleanPackageCache", "CleanTracker",
+                      "RestartFingerprint"]
         for (var i = 0; i < names.length; ++i)
             justLoad(names[i])
     }

--- a/qml/plugins/RestartFingerprint.qml
+++ b/qml/plugins/RestartFingerprint.qml
@@ -1,0 +1,19 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Utilities 1.0
+
+ActionItem {
+    //% "Fingerprint"
+    title: qsTrId("sailfish-tools-he-fingerprint")
+    //% "Restart"
+    actionName: qsTrId("sailfish-tools-bt-fingerprint_restart")
+    deviceLockRequired: false
+    //% "Restart fingerprint service. In some circumstancces this can "
+    //% "resolve issues where valid fingerprints are no longer being "
+    //% "recognised."
+    description: qsTrId("sailfish-utilities-restart-fingerprint_desc")
+
+    function action(on_reply, on_error) {
+        UtilTools.restartFingerprint(on_reply, on_error)
+    }
+}

--- a/sailfish-utilities.pro
+++ b/sailfish-utilities.pro
@@ -1,11 +1,18 @@
 TEMPLATE = aux
 
-PROJECTS = qml plugin qml/plugins
+PROJECTS = qml plugin qml/plugins tools
 
 message($${PROJECTS})
-OTHER_FILES += *.qml *.js
+OTHER_FILES += *.qml *.js *.txt qmldir
+HEADERS += *.h
+SOURCES += *.cpp
 for (PROJECT, PROJECTS) {
     OTHER_FILES += $${PROJECT}/*.qml \
-                   $${PROJECT}/*.js
+                   $${PROJECT}/*.js \
+                   $${PROJECT}/*.txt \
+                   $${PROJECT}/qmldir \
+                   $${PROJECT}/*.sh \
+                   $${PROJECT}/*.in
+    HEADERS += $${PROJECT}/*.h
+    SOURCES += $${PROJECT}/*.cpp
 }
-j

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -22,5 +22,6 @@ install(PROGRAMS
       restart_network.sh
       restart_lipstick.sh
       tracker_reindex.sh
+      restart_fingerprint.sh
       DESTINATION share/sailfish-utilities
 )

--- a/tools/restart_fingerprint.sh
+++ b/tools/restart_fingerprint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+warning() {
+    printf "%s: Warning: %s\n" "$(basename $0)" "${@}" 1>&2;
+}
+
+service_do() {
+    if systemctl "$1" "$2"; then
+        return 0;
+    else
+        warning "Status $? on" "${@}"
+        return 1;
+    fi
+}
+
+service_do restart sailfish-fpd
+sleep 3
+service_do restart sailfish-fpd

--- a/tools/sailfish_tools_system_action.cpp
+++ b/tools/sailfish_tools_system_action.cpp
@@ -66,11 +66,14 @@ std::map<std::string, action_type> actions = {
         }},
     { "tracker_reindex", [](action_ctx const *) {
             return execute_own_utility("tracker_reindex.sh");
+        }},
+    { "restart_fingerprint", [](action_ctx const *) {
+            return execute_own_utility("restart_fingerprint.sh");
         }}
 };
 
 std::set<std::string> root_actions = {
-    "repair_rpm_db", "restart_network"
+    "repair_rpm_db", "restart_network", "restart_fingerprint"
 };
 
 class BecomeRoot


### PR DESCRIPTION
Adds a button for restarting the fingerprint service. In practice, it
restarts, waits 10 seconds and then restarts again.

In some situations where the fingerprint cache gets messed up, which
prevents fingerprints from being recognised, this sequence resolves the
issue.