### PR TITLE
[sailfish-utilities] Add scrollbar to main page.

### DIFF
--- a/qml/MainPage.qml
+++ b/qml/MainPage.qml
@@ -69,9 +69,11 @@ Page {
         anchors.fill: parent
         contentHeight: actionList.height + Theme.paddingLarge
 
+        VerticalScrollDecorator { flickable: mainView }
+
         ActionList {
             id: actionList
-            
+
             opacity: mainPage.inProgress ? 0.0 : 1.0
             Behavior on opacity { FadeAnimation {} }
             onDone: {


### PR DESCRIPTION
The main page is longer than the screen of my Xperia X, and there is no scrolling indicator at the moment. This PR adds one.