### PR TITLE
[sailfish-utilities] Add restart keyboard action.

### DIFF
--- a/qml/ActionList.qml
+++ b/qml/ActionList.qml
@@ -28,7 +28,7 @@ Column {
             var info = { name: name, path: "plugins/" + name + ".qml" }
             plugins.append(info)
         }
-        var names = [ "RestartNetwork", "RestartUI",
+        var names = [ "RestartNetwork", "RestartKeyboard", "RestartUI",
                       "RestartFingerprint", "RestartBluetooth",
                       "CleanPackageCache", "CleanTracker"
                     ]

--- a/qml/plugins/RestartKeyboard.qml
+++ b/qml/plugins/RestartKeyboard.qml
@@ -1,0 +1,27 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import Sailfish.Utilities 1.0
+import Nemo.DBus 2.0
+
+ActionItem {
+    //% "Keyboard"
+    title: qsTrId("sailfish-tools-he-keyboard")
+    //% "Restart"
+    actionName: qsTrId("sailfish-tools-bt-restart")
+    deviceLockRequired: false
+    //% "Restart the keyboard if it becomes unresponsive, keys are missing, " +
+    //% "or if it behaves otherwise incorrectly."
+    description: qsTrId("sailfish-utilities-me-restart-keyboard-desc")
+
+    DBusInterface {
+        id: service
+        bus: DBus.SessionBus
+        service: 'org.freedesktop.systemd1'
+        path: '/org/freedesktop/systemd1/unit/maliit_2dserver_2eservice'
+        iface: 'org.freedesktop.systemd1.Unit'
+    }
+
+    function action(on_reply, on_error) {
+        service.call("Restart", ["replace"], on_reply, on_error)
+    }
+}


### PR DESCRIPTION
This fixes #52 but I didn't mention it in the commit message because other commits refer to "JB" numbers while the contributing guidelines appear outdated.

The "restart keyboard" action was removed in ac4d84cf5063158602f6742b7c9383d6149a46f4 in 2016. My implementation uses a direct DBus call instead of going through the C++ side plus Bash.